### PR TITLE
Set cwd when calling Popen in linux

### DIFF
--- a/Kulture.py
+++ b/Kulture.py
@@ -142,7 +142,7 @@ class KTerminalCommand():
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
                 subprocess.Popen(args, cwd=cwd, startupinfo=startupinfo)
             elif plat == 'linux':
-                subprocess.Popen(args)
+                subprocess.Popen(args, cwd=cwd)
             else:
                 subprocess.Popen(args, cwd=cwd)
 


### PR DESCRIPTION
As in my previous PR in the old repository, I made a change to set the CWD when executing Popen in Linux. I couldn't execute any K command prior to this change, since it was not possible to find the project.json without specifying that parameter.
