### PR TITLE
Update Sublime build command to use bash explicitly

### DIFF
--- a/ASP.NET.sublime-build
+++ b/ASP.NET.sublime-build
@@ -1,5 +1,5 @@
 {
-	"cmd": ["sh", "$packages/Kulture/build.sh"],
+	"cmd": ["bash", "$packages/Kulture/build.sh"],
 	"working_dir": "${project_path}",
 	"file_regex": "(.*)\\(([0-9]+),([0-9]+)\\): (?:error|warning) [A-Z,0-9]+",
 	"windows":


### PR DESCRIPTION
sh is linked to dash by default on Debian based systems, which causes the build script to fail.  build.sh has bash listed as its interpreter, so this should not cause any problems.