### PR TITLE
Updated the build.sh file to reflect the new kpm beta3 directory structure.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Add K to path and trigger build
-ver=`cat ~/.kre/alias/default.alias`
-add_to_path=$HOME"/.kre/packages/"$ver"/bin"
+ver=`cat ~/.k/alias/default.alias`
+add_to_path=$HOME"/.k/runtime/"$ver"/bin"
 export PATH=$PATH:/usr/local/bin:$add_to_path
-[ -s $HOME"/.kre/kvm/kvm.sh" ] && . $HOME"/.kre/kvm/kvm.sh"
+[ -s $HOME"/.k/kvm/kvm.sh" ] && . $HOME"/.k/kvm/kvm.sh"
 directory="./"
 temp=$directory"project.json"
 counter=0


### PR DESCRIPTION
Hi, 

I've updated the build.sh file to reflect the new kpm (beta3) directory structure, where it moves to .k instead of .kre. 

Also, the previous *packages* directory has moved to *runtime*.