### PR TITLE
Fixed typo in path which caused builds to not run

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Add K to path and trigger build
 ver=`cat ~/.k/alias/default.alias`
-add_to_path=$HOME"/.k/runtime/"$ver"/bin"
+add_to_path=$HOME"/.k/runtimes/"$ver"/bin"
 export PATH=$PATH:/usr/local/bin:$add_to_path
 [ -s $HOME"/.k/kvm/kvm.sh" ] && . $HOME"/.k/kvm/kvm.sh"
 directory="./"


### PR DESCRIPTION
Just a simple typo, but was causing me not to be able to run builds or get anything working. Hopefully you can merge it okay.

Thx for your hard work, its a great plugin!