### PR TITLE
Display an error instead of aborting

### DIFF
--- a/Completions.py
+++ b/Completions.py
@@ -24,6 +24,9 @@ class KKultureCompletion( sublime_plugin.EventListener):
         while(self.thread.is_alive()):
             pass
         response = self.thread.response
+        if not response:
+            print (self.thread.message)
+            return
         for package in response:
             t = (package['Id'],package['Id'])
             # if t not in self.result:


### PR DESCRIPTION
See issue #29.
If myget.org can't be reached, the script will show the next message in the Sublime Text console:
```
URL error [Errno -2] Name or service not known contacting API
```
instead of
```
Traceback (most recent call last):
  File "/opt/sublime_text/sublime_plugin.py", line 97, in reload_plugin
    obj = t()
  File "/home/username/.config/sublime-text-3/Packages/Kulture/Completions.py", line 27, in __init__
    for package in response:
TypeError: 'bool' object is not iterable
```